### PR TITLE
chore: upgrade Node.js to 24 LTS and enable min-release-age

### DIFF
--- a/.github/workflows/test-vectors.yml
+++ b/.github/workflows/test-vectors.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [24.x]
 
     steps:
       - uses: actions/checkout@v6

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   ],
   "collaborators": [
     "nikkolasg",
-    "Georgios Konstantopoulos"
+    "Georgios Konstantopoulos",
+    "Paul Lange"
   ],
   "files": [
     "README.md",
@@ -31,6 +32,9 @@
   },
   "devDependencies": {
     "jest": "^30.0.0"
+  },
+  "engines": {
+    "node": ">=24"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Bump CI matrix and `engines.node` to Node 24 (Active LTS as of April 2026)
- Add `.npmrc` with `min-release-age=7` for supply-chain protection (delays installing freshly-published versions for 7 days)
- Add Paul Lange to collaborators

`min-release-age` requires npm 11, which ships with Node 24, so the two upgrades pair together.

## Test plan
- [ ] CI green on Node 24
- [ ] `npm install` honors the 7-day cooldown (requires npm >= 11.10.0)