### PR TITLE
chore: post-Node-upgrade improvements (CI hardening, README, audit fix)

### DIFF
--- a/.github/workflows/test-vectors.yml
+++ b/.github/workflows/test-vectors.yml
@@ -6,9 +6,13 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     strategy:
       matrix:
@@ -21,9 +25,10 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run tests
         run: npm test

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ node examples/tblind.js
 // Simple Example of blinding, signing, unblinding and verifying.
 
 // Import the library
-const threshold = require("@celo/blind_threshold_bls")
+const threshold = require("@celo/blind-threshold-bls")
 const crypto = require('crypto')
 
 // Get a message and a secret for the user
@@ -64,7 +64,7 @@ console.log("Verification successful")
 // Example of how threshold signing is expected to be consumed from the JS side
 
 // Import the library
-const threshold = require("@celo/blind_threshold_bls")
+const threshold = require("@celo/blind-threshold-bls")
 const crypto = require('crypto')
 // Helper
 function flattenSigsArray(sigs) {
@@ -88,7 +88,7 @@ const keys = threshold.thresholdKeygen(n, t, crypto.randomBytes(32))
 const shares = keys.shares
 const polynomial = keys.polynomial
 
-// each of these shares proceed to sign teh blinded sig
+// each of these shares proceed to sign the blinded sig
 let sigs = []
 for (let i = 0 ; i < keys.numShares(); i++ ) {
     const sig = threshold.partialSign(keys.getShare(i), blindedMessage)
@@ -105,7 +105,7 @@ const blindSig = threshold.combine(t, flattenSigsArray(sigs))
 // User unblinds the combined threshold signature with his scalar
 const sig = threshold.unblind(blindSig, blinded.blindingFactor)
 
-// User verifies the unblinded signautre on his unblinded message
+// User verifies the unblinded signature on his unblinded message
 threshold.verify(keys.thresholdPublicKey, msg, sig)
 console.log("Verification successful")
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "jest": "^30.0.0"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1576,9 +1579,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1718,9 +1721,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3510,9 +3513,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3877,9 +3880,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Three small, independent commits — review per commit.

## Summary
- **ci: harden test workflow** — switch to `npm ci`, enable `actions/setup-node` npm cache, declare least-privilege `permissions: contents: read`, add a 10-minute job timeout.
- **docs: fix package name and typos in README examples** — examples imported `@celo/blind_threshold_bls` (underscore) instead of the published `@celo/blind-threshold-bls` (dash), so copy-pasting failed. Also fixes "teh" and "signautre".
- **chore: npm audit fix** — lockfile-only bumps for `brace-expansion` and `picomatch`, clearing 3 advisories. Tests still pass locally.

## Test plan
- [ ] CI green on Node 24 with the new `npm ci` + cache config
- [ ] `npm test` passes
- [ ] No new advisories from `npm audit`