### PR TITLE
chore: package.json metadata polish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
   "name": "@celo/blind-threshold-bls",
   "version": "1.0.0-beta",
+  "description": "WASM bindings for blind BLS threshold signature generation and verification",
   "private": false,
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/celo-org/blind-threshold-bls-wasm"
+  },
+  "homepage": "https://github.com/celo-org/blind-threshold-bls-wasm#readme",
+  "bugs": {
+    "url": "https://github.com/celo-org/blind-threshold-bls-wasm/issues"
   },
   "keywords": [
     "bls",
@@ -34,7 +39,8 @@
     "jest": "^30.0.0"
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=24",
+    "npm": ">=11"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -18,11 +18,6 @@
     "wasm",
     "celo"
   ],
-  "collaborators": [
-    "nikkolasg",
-    "Georgios Konstantopoulos",
-    "Paul Lange"
-  ],
   "files": [
     "README.md",
     "src/blind_threshold_bls_bg.wasm",


### PR DESCRIPTION
## Summary
- Adds `description`, `homepage`, and `bugs.url` so the package renders properly on npmjs.com
- Pins `engines.npm >= 11` (required for the `min-release-age` setting added in #18 to take effect — it silently no-ops on older npm)
- Removes the non-standard `collaborators` field — npm's spec doesn't define it, so it was just dead JSON in the registry manifest

## Test plan
- [ ] `npm publish --dry-run` shows the new metadata in the manifest
- [ ] CI green